### PR TITLE
Modify initial template

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,40 @@
+# {{ cookiecutter.project_name }} Code of Conduct
+
+## HHS Open Data Values
+HHS is dedicated to providing a safe, harassment-free, positive environment for everyone, regardless of race, ethnicity, sex, sexual orientation, religion, or disability. 
+HHS does not tolerate harassment of members of our community under any circumstances.  
+
+By contributing to this repository, you agree to adhere to the rules set forth in this document and uphold the  core values underpinning the HHS Open Data community to foster a community built on openness, kindness, and collective benefit. These core values also serve as the code of conduct foundation for HHS Open Source repositories:  
+
+1. **TRANSPARENCY:** Radical openness by default.
+2. **PURPOSE:** Data that serves the public good.
+3. **RELENTLESS OPTIMIZATION:** Adapt, refine, and improve through two-way feedback, accountability, and a growth mindset.
+4. **EXCELLENCE:** Real-world evidence drives impact.
+5. **RESPECT:** The public and patients as equal partners.
+6. **INTEGRITY:** Find the truth. Tell the truth.
+
+## Code of Conduct
+
+The below section describes the do’s and don’ts while engaging with any HHS Open Source repository and should be followed at all times. Failure to comply with these expectations may result in permanent removal from the project repository.  
+
+### Expected Behavior
+* Use respectful and constructive language when interacting with fellow community members and submitting feedback to maintainers.
+* Escalate unresolved issues or discussion questions to maintainers for review and/or mediation.
+* Report any security vulnerabilities, malicious activity, or harmful behavior to maintainers immediately.
+* Remain in-scope within all communications across the repository. Stay on topic!  
+
+### Inappropriate Behavior
+* Do not personally attack, harass, or discriminate any member of the community.
+  * Discrimination based on race, ethnicity, sex, sexual orientation, religion, or disability are strictly prohibited.
+* Do not introduce malicious code, spam, or otherwise harmful content.
+* Refrain from using inappropriate language, photos, or other content.
+* Sharing personally identifiable information (PII), protected health information (PHI) or other sensitive data is not allowed.
+* Continual disruption of discussions, announcements, or other project-related engagement is prohibited.
+
+## Acknowledgement
+By joining and contributing to this repository and its associated materials, discussions, and forms, you agree to the adhere to the expected behaviors and decorum detailed in this document.
+
+## Contact Information
+For questions, concerns, or reporting violations of the code of conduct, please contact the repository maintainers at [CDO@hhs.gov](mailto:cdo@hhs.gov).  
+
+All reports received for code of conduct violations will be reviewed, investigated, and will result in a response that is deemed appropriate given the context of the circumstance(s). Persons found in violation of the code of conduct may receive a formal warning to cease their behavior or be removed from the community indefinitely.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,13 +96,11 @@ docs. Please file an [issue](https://github.com/{{ cookiecutter.project_org }}/{
 
 ### Open Source Policy
 
-We adhere to the [CMS Open Source
-Policy](https://github.com/CMSGov/cms-open-source-policy). If you have any
-questions, just [shoot us an email](mailto:opensource@cms.hhs.gov).
+We adhere to the [HHS Open Source Policy](https://www.hhs.gov/sites/default/files/hhs-open-gov-plan-v4-2016.pdf). If you have any questions, just [send us an email](mailto:cdo@hhs.gov).
 
 ### Security and Responsible Disclosure Policy
 
-*Submit a vulnerability:* Vulnerability reports can be submitted through [Bugcrowd](https://bugcrowd.com/cms-vdp). Reports may be submitted anonymously. If you share contact information, we will acknowledge receipt of your report within 3 business days.
+_Submit a vulnerability:_ Vulnerability reports can be submitted through processes listed on the [HHS VDP Page](https://www.hhs.gov/vulnerability-disclosure-policy/index.html).
 
 For more information about our Security, Vulnerability, and Responsible Disclosure Policies, see [SECURITY.md](SECURITY.md).
 

--- a/README.md
+++ b/README.md
@@ -110,13 +110,11 @@ Information about terminology and acronyms used in this documentation may be fou
 
 ### Open Source Policy
 
-We adhere to the [CMS Open Source
-Policy](https://github.com/CMSGov/cms-open-source-policy). If you have any
-questions, just [shoot us an email](mailto:opensource@cms.hhs.gov).
+We adhere to the [HHS Open Source Policy](https://www.hhs.gov/sites/default/files/hhs-open-gov-plan-v4-2016.pdf). If you have any questions, just [send us an email](mailto:cdo@hhs.gov).
 
 ### Security and Responsible Disclosure Policy
 
-_Submit a vulnerability:_ Vulnerability reports can be submitted through [Bugcrowd](https://bugcrowd.com/cms-vdp). Reports may be submitted anonymously. If you share contact information, we will acknowledge receipt of your report within 3 business days.
+_Submit a vulnerability:_ Vulnerability reports can be submitted through processes listed on the [HHS VDP Page](https://www.hhs.gov/vulnerability-disclosure-policy/index.html). 
 
 For more information about our Security, Vulnerability, and Responsible Disclosure Policies, see [SECURITY.md](SECURITY.md).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,12 +1,6 @@
 # Security and Responsible Disclosure Policy
 
-The Centers for Medicare & Medicaid Services is committed to ensuring the security of the American public by protecting their information from unwarranted disclosure. We want security researchers to feel comfortable reporting vulnerabilities they have discovered so we can fix them and keep our users safe. We developed our disclosure policy to reflect our values and uphold our sense of responsibility to security researchers who share their expertise with us in good faith.
-
-*Submit a vulnerability:* Vulnerability reports can be submitted through [Bugcrowd](https://bugcrowd.com/cms-vdp). Reports may be submitted anonymously. If you share contact information, we will acknowledge receipt of your report within 3 business days.
-
 Review the HHS Disclosure Policy and websites in scope:
 [https://www.hhs.gov/vulnerability-disclosure-policy/index.html](https://www.hhs.gov/vulnerability-disclosure-policy/index.html).
 
-This policy describes *what systems and types of research* are covered under this
-policy, *how to send* us vulnerability reports, and *how long* we ask security
-researchers to wait before publicly disclosing vulnerabilities.
+This policy describes *what systems and types of research* are covered under this policy, *how to send* us vulnerability reports, and *how long* we ask security researchers to wait before publicly disclosing vulnerabilities.


### PR DESCRIPTION
### Problem
HHS doesn't have a specific tier 1 outbounding template. As more and more HHS repositories are being brought through the process, it becomes integral to the process to automate as much of it as possible, as well as provide clear documentation.

### Solution
Create a tier 1 template specific to HHS.
- Modify:
  - `COMMUNITY.md`
  - `CONTRIBUTING.md`
  - `README.md`
  - `SECURITY.md`
- Add:
  - `CODE_OF_CONDUCT.md`

### Result
Tier 1 template draft for HHS

### Next Steps
- Solidify language
- Add vanilla json
- Edit `cookiecutter.json`